### PR TITLE
Exclude only unnecessary files from being staged

### DIFF
--- a/bin/make-release.sh
+++ b/bin/make-release.sh
@@ -34,7 +34,11 @@ git rm -rf vendor
 rm -rf vendor
 rm -f composer.lock
 composer install || fail "composer install failed"
-find vendor/ -type f -name "*.php" \
+find vendor/ -type f -name "*" \
+ | grep -v '/docs/' \
+ | grep -v '/doc/' \
+ | grep -v '/\.[a-zA-Z0-9_]*' \
+ | grep -v 'phpunit*' \
  | grep -v '/examples/' \
  | grep -v '/example/' \
  | grep -v '/tests/' \


### PR DESCRIPTION
Currently all files except files with `.php` extension are excluded from being staged in `make-release.sh`. This has been changed to stage all files except unnecessary files.