### PR TITLE
Add `ramsey/collection` PHP 8.1 support patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
         "sort-packages": true,
         "platform": {
             "php": "7.2.9"
+        },
+        "allow-plugins": {
+            "cweagans/composer-patches": true
         }
     },
     "support": {
@@ -26,6 +29,7 @@
         "clue/socks-react": "^1.4",
         "clue/stdio-react": "^2.6",
         "components/jquery": "3.6.*",
+        "cweagans/composer-patches": "~1.0",
         "dompdf/dompdf": "^2.0.3",
         "erusev/parsedown": "^1.7.4",
         "evenement/evenement": "^3.0.1",
@@ -59,5 +63,13 @@
         "post-update-cmd": [
             "AssetLoader::update"
         ]
+    },
+    "extra": {
+        "composer-exit-on-patch-failure": true,
+        "patches": {
+            "ramsey/collection": {
+                "Collection: Add PHP 8.1 support": "patches/ramsey-collection.patch"
+            }
+        }
     }
 }

--- a/patches/ramsey-collection.patch
+++ b/patches/ramsey-collection.patch
@@ -1,0 +1,32 @@
+--- a/vendor/ramsey/collection/src/AbstractArray.php
++++ b/vendor/ramsey/collection/src/AbstractArray.php
+@@ -84,6 +84,7 @@ abstract class AbstractArray implements ArrayInterface
+      * @return T|null the value stored at the offset, or null if the offset
+      *     does not exist.
+      */
++    #[\ReturnTypeWillChange]
+     public function offsetGet($offset)
+     {
+         return $this->data[$offset] ?? null;
+--- a/vendor/ramsey/collection/src/AbstractCollection.php
++++ b/vendor/ramsey/collection/src/AbstractCollection.php
+@@ -51,6 +51,16 @@ abstract class AbstractCollection extends AbstractArray implements CollectionInt
+     use ValueToStringTrait;
+     use ValueExtractorTrait;
+ 
++    public function __serialize()
++    {
++        $this->serialize();
++    }
++
++    public function __unserialize(array $data)
++    {
++        $this->unserialize($data);
++    }
++
+     /**
+      * @inheritDoc
+      */
+--
+2.41.0
+


### PR DESCRIPTION
```bash
root@cab25752d670:/usr/share/icinga-php/vendor# composer update
Gathering patches for root package.
Removing package ramsey/collection so that it can be re-installed and re-patched.
  - Removing ramsey/collection (1.1.4)
...
Package operations: 1 install, 0 updates, 0 removals
Gathering patches for dependencies. This might take a minute.
  - Installing ramsey/collection (1.1.4): Extracting archive
  - Applying patches for ramsey/collection
    patches/ramsey-collection.patch (Collection: Add PHP 8.1 support)
```