### PR TITLE
Add patch for backward compatibility in shardj/zf1-future

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,9 @@
         "patches": {
             "ramsey/collection": {
                 "Collection: Add PHP 8.1 support": "patches/ramsey-collection.patch"
+            },
+            "shardj/zf1-future": {
+                "ZF1-Future: ZF backward compatibility": "patches/shardj-zf1-future.patch"
             }
         }
     }

--- a/patches/shardj-zf1-future.patch
+++ b/patches/shardj-zf1-future.patch
@@ -1,0 +1,11 @@
+--- a/vendor/shardj/zf1-future/library/Zend/Form/Element.php
++++ b/vendor/shardj/zf1-future/library/Zend/Form/Element.php
+@@ -595,7 +595,7 @@ class Zend_Form_Element implements Zend_Validate_Interface
+      * @param  string $key
+      * @return void
+      */
+-    protected function _filterValue(&$value, $key)
++    protected function _filterValue(&$value, &$key)
+     {
+         foreach ($this->getFilters() as $filter) {
+             $value = $filter->filter($value);


### PR DESCRIPTION
`Zend_Form_Element::_filterValue()` method signature has been changed in shardj/zf1-future and hence a patch has been added for the backward compatibility with zend framework