### PR TITLE
Clarify licensing for bundled third-party components

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,18 @@
-# MIT License
+# MIT License — Applies to Icinga-authored Files
+
+This package contains both Icinga-authored packaging glue and bundled
+third-party components.
+
+The MIT license below applies to Icinga-authored files in this package
+unless a file or directory states otherwise. This includes repository metadata,
+helper scripts, and other Icinga-specific glue code.
+
+Bundled third-party components are not covered by this license. They remain
+available under their respective upstream licenses. See
+[`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md) for bundled components
+and shipped assets under licenses other than MIT, including relevant indirect
+dependencies, and see the bundled license files under `vendor/` and `asset/`
+for the full license texts shipped with this package.
 
 Copyright (c) 2018 Icinga GmbH https://icinga.com
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-The MIT License
+# MIT License
 
-Copyright (c) 2018 Icinga GmbH https://www.icinga.com
+Copyright (c) 2018 Icinga GmbH https://icinga.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ INSTALL_PATH="/usr/share/icinga-php/vendor"
 INSTALL_VERSION="stable/0.13.0"
 git clone https://github.com/Icinga/icinga-php-thirdparty.git "$INSTALL_PATH" --branch "$INSTALL_VERSION"
 ```
+
+## License
+
+This package bundles third-party components under multiple upstream licenses.
+Icinga-authored packaging glue is licensed under MIT as described in
+[`LICENSE.md`](LICENSE.md), while bundled third-party components retain their
+respective upstream licenses. See
+[`THIRD_PARTY_LICENSES.md`](THIRD_PARTY_LICENSES.md) for bundled components
+and shipped assets under licenses other than MIT, including relevant indirect
+dependencies, and see the bundled license files under `vendor/` and `asset/`
+for the full license texts shipped with this package.

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,0 +1,30 @@
+# Third-Party Licenses
+
+This package bundles third-party components used by Icinga Web.
+Each bundled component remains available under its upstream license.
+
+This file highlights bundled components and shipped assets under licenses other
+than MIT.
+
+## License Summary
+
+| License           | Component                                                     | License Files / Notes                                                                                                     |
+|-------------------|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| Apache-2.0        | [wikimedia/less.php](https://github.com/wikimedia/less.php)   | [`vendor/wikimedia/less.php/LICENSE`](vendor/wikimedia/less.php/LICENSE)                                                  |
+| Apache-2.0        | [zircote/swagger-php](https://github.com/zircote/swagger-php) | [`vendor/zircote/swagger-php/LICENSE`](vendor/zircote/swagger-php/LICENSE)                                                |
+| BSD-3-Clause      | [icinga/zf1](https://github.com/Icinga/zf1)                   | [`vendor/icinga/zf1/LICENSE.txt`](vendor/icinga/zf1/LICENSE.txt)                                                          |
+| BSD-3-Clause      | [jfcherng/php-diff](https://github.com/jfcherng/php-diff)     | [`vendor/jfcherng/php-diff/LICENSE`](vendor/jfcherng/php-diff/LICENSE)                                                    |
+| BSD-3-Clause      | [tedivm/jshrink](https://github.com/tedious/JShrink)          | [`vendor/tedivm/jshrink/LICENSE`](vendor/tedivm/jshrink/LICENSE)                                                          |
+| ISC               | [d3.js](https://d3js.org/)                                    | [`asset/js/mbostock/LICENSE`](asset/js/mbostock/LICENSE); shipped as [`asset/js/mbostock/d3.js`](asset/js/mbostock/d3.js) |
+| LGPL-2.1          | [dompdf/dompdf](https://github.com/dompdf/dompdf)             | [`vendor/dompdf/dompdf/LICENSE.LGPL`](vendor/dompdf/dompdf/LICENSE.LGPL)                                                  |
+| LGPL-2.1-or-later | [ezyang/htmlpurifier](https://github.com/ezyang/htmlpurifier) | [`vendor/ezyang/htmlpurifier/LICENSE`](vendor/ezyang/htmlpurifier/LICENSE)                                                |
+| LGPL-3.0-or-later | [dompdf/php-svg-lib](https://github.com/dompdf/php-svg-lib)   | [`vendor/dompdf/php-svg-lib/LICENSE`](vendor/dompdf/php-svg-lib/LICENSE); bundled through the `dompdf/dompdf` dependency  |
+
+## Notes
+
+- This file lists top-level bundled components and additional shipped assets.
+- Components under MIT are not listed individually here.
+- Indirect dependencies are not listed one by one, but licenses they add to the
+  shipped source tree are still reflected here when relevant. For example,
+  `dompdf/dompdf` brings in a bundled `LGPL-3.0-or-later` dependency, so that
+  license is included above.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "icinga/icinga-php-thirdparty",
     "description": "Icinga Web - Bundle for all 3rd party PHP libraries",
-    "license": "MIT",
+    "license": "(MIT and LicenseRef-Icinga-Bundled-Upstream)",
     "type": "project",
     "homepage": "https://github.com/Icinga/icinga-php-thirdparty",
     "require": {


### PR DESCRIPTION
This package bundles third-party components under multiple upstream
licenses rather than a single package-wide MIT license.

- Adjust the misleading `license` entry in `composer.json`.
- Rename the root license file to `LICENSE.md`.
- Scope the MIT text to Icinga-authored packaging glue.
- Add `THIRD_PARTY_LICENSES.md` for non-MIT bundled components and assets.
- Align `README.md` wording with the new licensing layout.