### PR TITLE
`composer remove wikimedia/less.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,6 @@
         "react/stream": "^1.4",
         "simshaun/recurr": "^5.0.3",
         "tedivm/jshrink": "^1.8.1",
-        "wikimedia/less.php": "^3.2.1",
         "zircote/swagger-php": "^6.0.6"
     },
     "repositories": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "216e0359eaa1de0aaf7cd9207aeafb8f",
+    "content-hash": "4a001cab1f055862d7358cec5f70613c",
     "packages": [
         {
             "name": "brick/math",
@@ -4793,81 +4793,6 @@
                 }
             ],
             "time": "2026-02-04T18:08:13+00:00"
-        },
-        {
-            "name": "wikimedia/less.php",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wikimedia/less.php.git",
-                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/0d5b30ba792bdbf8991a646fc9c30561b38a5559",
-                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.9"
-            },
-            "require-dev": {
-                "mediawiki/mediawiki-codesniffer": "40.0.1",
-                "mediawiki/mediawiki-phan-config": "0.12.0",
-                "mediawiki/minus-x": "1.1.1",
-                "php-parallel-lint/php-console-highlighter": "1.0.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpunit/phpunit": "^8.5"
-            },
-            "bin": [
-                "bin/lessc"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Less": "lib/"
-                },
-                "classmap": [
-                    "lessc.inc.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Timo Tijhof",
-                    "homepage": "https://timotijhof.net"
-                },
-                {
-                    "name": "Josh Schmidt",
-                    "homepage": "https://github.com/oyejorge"
-                },
-                {
-                    "name": "Matt Agar",
-                    "homepage": "https://github.com/agar"
-                },
-                {
-                    "name": "Martin Jantošovič",
-                    "homepage": "https://github.com/Mordred"
-                }
-            ],
-            "description": "PHP port of the LESS processor",
-            "homepage": "https://gerrit.wikimedia.org/g/mediawiki/libs/less.php",
-            "keywords": [
-                "css",
-                "less",
-                "less.js",
-                "lesscss",
-                "php",
-                "stylesheet"
-            ],
-            "support": {
-                "issues": "https://github.com/wikimedia/less.php/issues",
-                "source": "https://github.com/wikimedia/less.php/tree/v3.2.1"
-            },
-            "time": "2023-02-03T06:43:41+00:00"
         },
         {
             "name": "zircote/swagger-php",


### PR DESCRIPTION
Until Icinga Web 2.14.0, Less to CSS compilation was handled by Icinga Web itself, making `wikimedia/less.php` a required dependency. Starting with 2.14.0, Less compilation is provided by `ipl\Web`, which renders this entry unnecessary.

Listing the dependency here was already questionable regardless, as `icinga-php-library` has carried `wikimedia/less.php` since version `0.13.0` — roughly three years ago.

closes #98
refs Icinga/ipl-web#365
refs Icinga/icingaweb2#5492